### PR TITLE
fix: Remove reinitialization of output variable in rb_solver

### DIFF
--- a/easyhec/optim/rb_solver.py
+++ b/easyhec/optim/rb_solver.py
@@ -73,9 +73,8 @@ class RBSolver(nn.Module):
                     Tc_c2l = Tc_c2b @ mount_poses[bid] @ link_poses[bid, link_idx]
                 else:
                     Tc_c2l = Tc_c2b @ link_poses[bid, link_idx]
-                verts, faces = (
-                    getattr(self, f"vertices_{link_idx}"),
-                    getattr(self, f"faces_{link_idx}"),
+                verts, faces = getattr(self, f"vertices_{link_idx}"), getattr(
+                    self, f"faces_{link_idx}"
                 )
                 si = self.renderer.render_mask(verts, faces, intrinsic, Tc_c2l)
                 all_link_si.append(si)
@@ -89,6 +88,8 @@ class RBSolver(nn.Module):
             losses.append(loss)
         loss = torch.stack(losses).mean()
         all_frame_all_link_si = torch.stack(all_frame_all_link_si)
+        
+        # metrics
         output = {
             "rendered_masks": all_frame_all_link_si,
             "ref_masks": masks_ref,

--- a/easyhec/optim/rb_solver.py
+++ b/easyhec/optim/rb_solver.py
@@ -73,8 +73,9 @@ class RBSolver(nn.Module):
                     Tc_c2l = Tc_c2b @ mount_poses[bid] @ link_poses[bid, link_idx]
                 else:
                     Tc_c2l = Tc_c2b @ link_poses[bid, link_idx]
-                verts, faces = getattr(self, f"vertices_{link_idx}"), getattr(
-                    self, f"faces_{link_idx}"
+                verts, faces = (
+                    getattr(self, f"vertices_{link_idx}"),
+                    getattr(self, f"faces_{link_idx}"),
                 )
                 si = self.renderer.render_mask(verts, faces, intrinsic, Tc_c2l)
                 all_link_si.append(si)
@@ -93,8 +94,7 @@ class RBSolver(nn.Module):
             "ref_masks": masks_ref,
             "error_maps": (all_frame_all_link_si - masks_ref.float()).abs(),
         }
-        # metrics
-        output = dict()
+
         if "gt_camera_pose" in data:
             gt_Tc_c2b = data["gt_camera_pose"]
             if not torch.allclose(gt_Tc_c2b, torch.eye(4).to(gt_Tc_c2b.device)):


### PR DESCRIPTION
# Change Summary

Variable output was being reinitialized after being set. the values that were being set are not used during optimization so it wasn't a problem for optimization

# Testing

Ran the sim example 

```bash
 python -m easyhec.examples.sim.maniskill -e StackCube-v1 --samples 5 --seed 2     --camera-name hand_camera     --initial-extrinsic-guess-rot-error 5 --initial-extrinsic-guess-pos-error 0.01
```
